### PR TITLE
HOTFIX: replace delim_whitespace (deprecated) with appropriate regex

### DIFF
--- a/notebook_helpers.py
+++ b/notebook_helpers.py
@@ -285,7 +285,7 @@ class TIData(DeltaGData):
             first_line = fin.readline()
         columns = re.split(" +", first_line)[1:-1]
         self.data = pd.read_csv(
-            infile, delim_whitespace=True, names=columns, comment="#", index_col=0
+            infile, sep="\\s+", names=columns, comment="#", index_col=0
         )
         self.data = self.data[self.data.index >= self.eqtime][1:]
         self.data.index = self.data.index - self.eqtime


### PR DESCRIPTION
fix #46 
Replace reference to delim_whitespace with appropriate regex
Notebook now runs as expected